### PR TITLE
fix: error with TestCafe context in mockApiRoute function

### DIFF
--- a/scripts/testEsmExports.ts
+++ b/scripts/testEsmExports.ts
@@ -12,6 +12,9 @@ const checkCreateTestCafe = async () => {
   runner.concurrency(1);
 
   await testCafe.close();
+
+  // eslint-disable-next-line no-console
+  console.log('[OK] ESM exports are correct');
 };
 
 // @ts-expect-error: top-level await is not allowed with "module": "CommonJS"

--- a/src/package/types/global.d.ts
+++ b/src/package/types/global.d.ts
@@ -20,6 +20,14 @@ declare module 'bin-v8-flags-filter' {
 }
 
 /**
+ * Internal ESM module, which is used to directly access to TestCafe exports.
+ * @internal
+ */
+declare module 'e2ed/testcafe' {
+  export const createTestCafe: typeof import('../testcafe').createTestCafe;
+}
+
+/**
  * Internal TestCafe module, which is used to track asynchronous calls in tests.
  * @internal
  */

--- a/src/package/utils/events/registerLogEvent.ts
+++ b/src/package/utils/events/registerLogEvent.ts
@@ -6,7 +6,7 @@ import type {LogEvent, RunId} from '../../types/internal';
  * Register log event (for report).
  * @internal
  */
-export const registerLogEvent = async (runId: RunId, logEvent: LogEvent): Promise<number> => {
+export const registerLogEvent = (runId: RunId, logEvent: LogEvent): Promise<number> => {
   const runTestEvent = getTestRunEvent(runId);
 
   const numberInRun = runTestEvent.logEvents.length;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: WEB-5540

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Now the test status will be calculated directly, without using the JSON reporter.
This will speed up and stabilize the passing of tests in case of "browser disconnect" errors.
