### PR TITLE
feat: fast errors loading (tests with errors) in HTML report

### DIFF
--- a/autotests/packs/allTests.ts
+++ b/autotests/packs/allTests.ts
@@ -41,6 +41,7 @@ export const pack: Pack = {
   mapLogPayloadInLogFile: (message, payload) => payload,
   mapLogPayloadInReport: (message, payload) => payload,
   maxRetriesCountInDocker: 3,
+  nativeAutomation: false,
   packTimeout: 90 * 60_000,
   pageRequestTimeout: 30_000,
   pageStabilizationInterval: 1_000,

--- a/src/actions/navigateToUrl.ts
+++ b/src/actions/navigateToUrl.ts
@@ -1,5 +1,7 @@
 import {LogEventType} from '../constants/internal';
 import {createClientFunction} from '../createClientFunction';
+import {testController} from '../testController';
+import {getFullPackConfig} from '../utils/getFullPackConfig';
 import {log} from '../utils/log';
 
 import type {Url, Void} from '../types/internal';
@@ -25,7 +27,13 @@ export const navigateToUrl = async (url: Url, options: Options = {}): Promise<vo
     log(`Will navigate to the url ${url}`, LogEventType.InternalAction);
   }
 
-  await clientNavigateToUrl(url);
+  const {nativeAutomation} = getFullPackConfig();
+
+  if (nativeAutomation) {
+    await testController.navigateTo(url);
+  } else {
+    await clientNavigateToUrl(url);
+  }
 
   if (skipLogs !== true) {
     log(`Navigation to the url ${url} completed`, LogEventType.InternalAction);

--- a/src/testcaferc.ts
+++ b/src/testcaferc.ts
@@ -39,7 +39,6 @@ const frozenPartOfTestCafeConfig: FrozenPartOfTestCafeConfig = {
     },
   },
   hostname: 'localhost',
-  nativeAutomation: false,
   pageLoadTimeout: 0,
   reporter: [{name: 'for-e2ed'}],
   retryTestPages: true,

--- a/src/types/config/config.ts
+++ b/src/types/config/config.ts
@@ -18,6 +18,7 @@ type UserlandTestCafeConfig = Readonly<{
   browserInitTimeout: number;
   browser: string;
   concurrency: number;
+  nativeAutomation: boolean;
   pageRequestTimeout: number;
   port1: number;
   port2: number;
@@ -36,7 +37,6 @@ export type FrozenPartOfTestCafeConfig = DeepReadonly<{
     };
   };
   hostname: string;
-  nativeAutomation: boolean;
   pageLoadTimeout: number;
   reporter: readonly {name: string; output?: string}[];
   retryTestPages: boolean;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -86,8 +86,10 @@ export type TestRunButtonProps = Readonly<{
  */
 export type ReportClientState = {
   clickListeners?: Record<string, (event: HTMLElement) => void>;
-  fullTestRuns?: readonly FullTestRun[];
-  pathToScreenshotsDirectoryForReport: string | null;
+  readonly fullTestRuns: readonly FullTestRun[];
+  lengthOfReadedJsonReportDataParts: number;
+  readonly pathToScreenshotsDirectoryForReport: string | null;
+  readonly readJsonReportDataIntervalId?: number;
   testRunDetailsElementsByHash?: Record<RunHash, HTMLElement>;
 };
 

--- a/src/utils/exit/getExitCode.ts
+++ b/src/utils/exit/getExitCode.ts
@@ -17,7 +17,7 @@ export const getExitCode = (hasErrors: boolean, retries: readonly Retry[]): Exit
     return ExitCode.NoRetries;
   }
 
-  const lastRetry = retries[retries.length - 1];
+  const lastRetry = retries.at(-1);
 
   assertValueIsDefined(lastRetry, 'lastRetry is defined', {retries});
 

--- a/src/utils/report/client/chooseTestRun.ts
+++ b/src/utils/report/client/chooseTestRun.ts
@@ -43,19 +43,13 @@ export function chooseTestRun(runHash: RunHash): void {
   }
 
   const {fullTestRuns} = reportClientState;
-
-  if (fullTestRuns === undefined) {
-    // eslint-disable-next-line no-console
-    console.log('JSON report data not yet loaded. Please try click again later');
-
-    return;
-  }
-
   const fullTestRun = fullTestRuns.find((testRun) => testRun.runHash === runHash);
 
   if (fullTestRun === undefined) {
     // eslint-disable-next-line no-console
-    console.error(`Cannot find test run with hash ${runHash} in JSON report data`);
+    console.error(
+      `Cannot find test run with hash ${runHash} in JSON report data. Probably JSON report data for this test run not yet loaded. Please try click again later`,
+    );
 
     return;
   }

--- a/src/utils/report/client/domContentLoadedHandler.ts
+++ b/src/utils/report/client/domContentLoadedHandler.ts
@@ -1,7 +1,10 @@
-import type {FullTestRun, ReportClientState} from '../../../types/internal';
+import {readJsonReportData as clientReadJsonReportData} from './readJsonReportData';
 
-declare const e2edJsonReportData: HTMLScriptElement;
+import type {Mutable, ReportClientState} from '../../../types/internal';
+
 declare const reportClientState: ReportClientState;
+
+const readJsonReportData = clientReadJsonReportData;
 
 /**
  * DOMContentloaded handler for report page.
@@ -9,9 +12,9 @@ declare const reportClientState: ReportClientState;
  * @internal
  */
 export function domContentLoadedHandler(): void {
-  const fullTestRuns = JSON.parse(
-    e2edJsonReportData.textContent ?? 'Cannot parse JSON report data',
-  ) as readonly FullTestRun[];
+  readJsonReportData();
 
-  reportClientState.fullTestRuns = fullTestRuns;
+  window.clearInterval(reportClientState.readJsonReportDataIntervalId);
+
+  (reportClientState as Mutable<ReportClientState>).readJsonReportDataIntervalId = 0;
 }

--- a/src/utils/report/client/index.ts
+++ b/src/utils/report/client/index.ts
@@ -17,6 +17,8 @@ export {domContentLoadedHandler} from './domContentLoadedHandler';
 /** @internal */
 export {initialScript} from './initialScript';
 /** @internal */
+export {readJsonReportData} from './readJsonReportData';
+/** @internal */
 export {
   renderDatesInterval,
   renderDuration,

--- a/src/utils/report/client/initialScript.ts
+++ b/src/utils/report/client/initialScript.ts
@@ -4,6 +4,11 @@ import {clickOnRetry as clientClickOnRetry} from './clickOnRetry';
 import {clickOnStep as clientClickOnStep} from './clickOnStep';
 import {clickOnTestRun as clientClickOnTestRun} from './clickOnTestRun';
 import {domContentLoadedHandler as clientDomContentLoadedHandler} from './domContentLoadedHandler';
+import {readJsonReportData as clientReadJsonReportData} from './readJsonReportData';
+
+import type {Mutable, ReportClientState} from '../../../types/internal';
+
+declare const reportClientState: ReportClientState;
 
 const addDomContentLoadedHandler = clientAddDomContentLoadedHandler;
 const addOnClickOnClass = clientAddOnClickOnClass;
@@ -11,9 +16,11 @@ const clickOnRetry = clientClickOnRetry;
 const clickOnStep = clientClickOnStep;
 const clickOnTestRun = clientClickOnTestRun;
 const domContentLoadedHandler = clientDomContentLoadedHandler;
+const readJsonReportData = clientReadJsonReportData;
 
 /**
  * Initial report page script.
+ * This client function should not use scope variables (except global functions).
  * @internal
  */
 export const initialScript = (): void => {
@@ -22,4 +29,11 @@ export const initialScript = (): void => {
   addOnClickOnClass('test-button', clickOnTestRun);
 
   addDomContentLoadedHandler(domContentLoadedHandler);
+
+  if (!('readJsonReportDataIntervalId' in reportClientState)) {
+    readJsonReportData();
+
+    (reportClientState as Mutable<ReportClientState>).readJsonReportDataIntervalId =
+      window.setInterval(readJsonReportData, 50);
+  }
 };

--- a/src/utils/report/client/readJsonReportData.ts
+++ b/src/utils/report/client/readJsonReportData.ts
@@ -1,0 +1,30 @@
+import type {FullTestRun, ReportClientState} from '../../../types/internal';
+
+declare const reportClientState: ReportClientState;
+
+/**
+ * Reads JSON report data from script tags.
+ * Not all tags can be loaded and inserted into the DOM by the time the function is called,
+ * so it must be called several times until the DOM is loaded.
+ * This client function should not use scope variables (except global functions).
+ * @internal
+ */
+export function readJsonReportData(): void {
+  const {lengthOfReadedJsonReportDataParts} = reportClientState;
+  const scripts = document.querySelectorAll('script.e2edJsonReportData');
+  const {length} = scripts;
+
+  if (length <= lengthOfReadedJsonReportDataParts) {
+    return;
+  }
+
+  for (let i = lengthOfReadedJsonReportDataParts; i < length; i += 1) {
+    const fullTestRuns = JSON.parse(
+      scripts[i]?.textContent ?? `Cannot parse JSON report data from script number ${i}`,
+    ) as readonly FullTestRun[];
+
+    (reportClientState.fullTestRuns as FullTestRun[]).push(...fullTestRuns);
+  }
+
+  reportClientState.lengthOfReadedJsonReportDataParts = length;
+}

--- a/src/utils/report/client/render/renderSteps.ts
+++ b/src/utils/report/client/render/renderSteps.ts
@@ -55,7 +55,7 @@ export function renderSteps({endTimeInMs, logEvents}: Options): SafeHtml {
         const pathToScreenshotFromReportPage = `${pathToDirectoryWithoutSlashes}/${pathToScreenshot}`;
 
         contentTag = 'div';
-        content = sanitizeHtml`<pre>${code}</pre><img src="${pathToScreenshotFromReportPage}" alt="Screenshot from test" loading="lazy">`;
+        content = sanitizeHtml`<pre>${code}</pre><img src="${pathToScreenshotFromReportPage}" alt="Screenshot from test">`;
       }
     }
 

--- a/src/utils/report/client/sanitizeHtml.ts
+++ b/src/utils/report/client/sanitizeHtml.ts
@@ -13,7 +13,7 @@ export function createSafeHtmlWithoutSanitize(
   stringParts: readonly string[],
   ...values: readonly unknown[]
 ): SafeHtml {
-  const key = Symbol.for('e2ed SafeHtml key');
+  const key = Symbol.for('e2ed:SafeHtml key');
   const parts: string[] = [];
 
   for (let index = 0; index < values.length; index += 1) {
@@ -50,7 +50,7 @@ export function sanitizeHtml(
   stringParts: readonly string[],
   ...values: readonly unknown[]
 ): SafeHtml {
-  const key = Symbol.for('e2ed SafeHtml key');
+  const key = Symbol.for('e2ed:SafeHtml key');
 
   const sanitizeValue = (value: unknown): string =>
     String(value)

--- a/src/utils/report/render/renderJsonData.ts
+++ b/src/utils/report/render/renderJsonData.ts
@@ -1,17 +1,55 @@
+import {FAILED_TEST_RUN_STATUSES} from '../../../constants/internal';
+
 import {createSafeHtmlWithoutSanitize, sanitizeJson} from '../client';
 
-import type {ReportData, SafeHtml} from '../../../types/internal';
+import type {FullTestRun, ReportData, SafeHtml} from '../../../types/internal';
+
+type FullTestRuns = readonly FullTestRun[];
+
+const filterErrors = (fullTestRuns: FullTestRuns): [errors: FullTestRuns, rest: FullTestRuns] => {
+  const errors: FullTestRun[] = [];
+  const rest: FullTestRun[] = [];
+
+  for (const fullTestRun of fullTestRuns) {
+    if (FAILED_TEST_RUN_STATUSES.includes(fullTestRun.status)) {
+      errors.push(fullTestRun);
+    } else {
+      rest.push(fullTestRun);
+    }
+  }
+
+  return [errors, rest];
+};
 
 /**
- * Renders tag <script type="application/json"> with JSON presentation of report data.
+ * Renders script tags with JSON presentation of report data.
+ * In first tag renders the errors of the last retry, then the entire last retry,
+ * then all the remaining errors, then all the remaining data.
  * @internal
  */
 export const renderJsonData = (reportData: ReportData): SafeHtml => {
-  const {fullTestRuns} = reportData;
+  const {retries} = reportData;
 
-  const json = JSON.stringify(fullTestRuns);
-  const sanitizedJson = sanitizeJson(json);
+  const fullTestRunsNotFromLastRetry: FullTestRun[] = [];
+  const lastRetry = retries.at(-1);
 
-  return createSafeHtmlWithoutSanitize`
-<script id="e2edJsonReportData" type="application/json">${sanitizedJson}</script>`;
+  for (let i = 0; i < retries.length - 1; i += 1) {
+    fullTestRunsNotFromLastRetry.push(...(retries[i]?.fullTestRuns ?? []));
+  }
+
+  const [lastRetryErrors, lastRetryRest] = filterErrors(lastRetry?.fullTestRuns ?? []);
+  const [restErrors, rest] = filterErrors(fullTestRunsNotFromLastRetry);
+
+  const parts: readonly FullTestRuns[] = [lastRetryErrors, lastRetryRest, restErrors, rest].filter(
+    (part) => part.length > 0,
+  );
+
+  const scripts = parts.map((fullTestRuns) => {
+    const json = JSON.stringify(fullTestRuns);
+    const sanitizedJson = sanitizeJson(json);
+
+    return createSafeHtmlWithoutSanitize`<script class="e2edJsonReportData" type="plain/text">${sanitizedJson}</script>`;
+  });
+
+  return createSafeHtmlWithoutSanitize`${scripts.join('')}`;
 };

--- a/src/utils/report/render/renderScriptConstants.ts
+++ b/src/utils/report/render/renderScriptConstants.ts
@@ -11,7 +11,11 @@ import type {ReportClientState, SafeHtml} from '../../../types/internal';
 export const renderScriptConstants = (): SafeHtml => {
   const {pathToScreenshotsDirectoryForReport} = getFullPackConfig();
 
-  const reportClientState: ReportClientState = {pathToScreenshotsDirectoryForReport};
+  const reportClientState: ReportClientState = {
+    fullTestRuns: [],
+    lengthOfReadedJsonReportDataParts: 0,
+    pathToScreenshotsDirectoryForReport,
+  };
 
   return createSafeHtmlWithoutSanitize`
 const reportClientState = ${JSON.stringify(reportClientState)};

--- a/src/utils/report/render/renderScriptFunctions.ts
+++ b/src/utils/report/render/renderScriptFunctions.ts
@@ -8,6 +8,7 @@ import {
   clickOnTestRun,
   createSafeHtmlWithoutSanitize,
   domContentLoadedHandler,
+  readJsonReportData,
   renderDatesInterval,
   renderDuration,
   renderSteps,
@@ -33,6 +34,7 @@ ${clickOnRetry.toString()}
 ${clickOnStep.toString()}
 ${clickOnTestRun.toString()}
 ${domContentLoadedHandler.toString()}
+${readJsonReportData.toString()}
 ${renderDatesInterval.toString()}
 ${renderDuration.toString()}
 ${renderSteps.toString()}


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Prior to this pull request, all test data was loaded into the report together and in its entirety. As a result, if there was a lot of data (many tests in the pack), it took a long time to load them.

## What is the new behavior?

Now the test data is loaded in parts - first the errors of the last retry, then the entire last retry, then all the remaining errors, then all the remaining data.
As a result, the user can view the errors of the last retray immediately, without waiting for all the data to be loaded.

## Other information

Additional fixes:
- feat: support nativeAutomation field in pack config (new TestCafe option)
- fix: support nativeAutomation in navigateToUrl action
- fix: load screenshots in HTML report immediately

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
