### PR TITLE
fix: mechanism of reading JSON report data from scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
       },
       "devDependencies": {
         "@types/node": "18.15.11",
-        "@typescript-eslint/eslint-plugin": "5.58.0",
-        "@typescript-eslint/parser": "5.58.0",
+        "@typescript-eslint/eslint-plugin": "5.59.0",
+        "@typescript-eslint/parser": "5.59.0",
         "assert-modules-support-case-insensitive-fs": "1.0.1",
         "assert-package-lock-is-consistent": "1.0.0",
         "eslint": "8.38.0",
@@ -1938,15 +1938,15 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.58.0.tgz",
-      "integrity": "sha512-vxHvLhH0qgBd3/tW6/VccptSfc8FxPQIkmNTVLWcCOVqSBvqpnKkBTYrhcGlXfSnd78azwe+PsjYFj0X34/njA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz",
+      "integrity": "sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/type-utils": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/type-utils": "5.59.0",
+        "@typescript-eslint/utils": "5.59.0",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -1984,9 +1984,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1999,14 +1999,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.58.0.tgz",
-      "integrity": "sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
+      "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2026,13 +2026,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
-      "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+      "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0"
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2043,13 +2043,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.58.0.tgz",
-      "integrity": "sha512-FF5vP/SKAFJ+LmR9PENql7fQVVgGDOS+dq3j+cKl9iW/9VuZC/8CFmzIP0DLKXfWKpRHawJiG70rVH+xZZbp8w==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz",
+      "integrity": "sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
+        "@typescript-eslint/utils": "5.59.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2070,9 +2070,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
-      "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+      "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2083,13 +2083,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
-      "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+      "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2143,9 +2143,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2158,17 +2158,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.58.0.tgz",
-      "integrity": "sha512-gAmLOTFXMXOC+zP1fsqm3VceKSBQJNzV385Ok3+yzlavNHZoedajjS4UyS21gabJYcobuigQPs/z71A9MdJFqQ==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
+      "integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -2196,9 +2196,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2211,12 +2211,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
-      "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+      "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.58.0",
+        "@typescript-eslint/types": "5.59.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -5015,9 +5015,9 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -8770,15 +8770,15 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.58.0.tgz",
-      "integrity": "sha512-vxHvLhH0qgBd3/tW6/VccptSfc8FxPQIkmNTVLWcCOVqSBvqpnKkBTYrhcGlXfSnd78azwe+PsjYFj0X34/njA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz",
+      "integrity": "sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/type-utils": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/type-utils": "5.59.0",
+        "@typescript-eslint/utils": "5.59.0",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -8797,9 +8797,9 @@
           }
         },
         "semver": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-          "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8808,53 +8808,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.58.0.tgz",
-      "integrity": "sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
+      "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
-      "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+      "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0"
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.58.0.tgz",
-      "integrity": "sha512-FF5vP/SKAFJ+LmR9PENql7fQVVgGDOS+dq3j+cKl9iW/9VuZC/8CFmzIP0DLKXfWKpRHawJiG70rVH+xZZbp8w==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz",
+      "integrity": "sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.58.0",
-        "@typescript-eslint/utils": "5.58.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
+        "@typescript-eslint/utils": "5.59.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
-      "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+      "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
-      "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+      "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/visitor-keys": "5.58.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -8887,9 +8887,9 @@
           }
         },
         "semver": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-          "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8898,17 +8898,17 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.58.0.tgz",
-      "integrity": "sha512-gAmLOTFXMXOC+zP1fsqm3VceKSBQJNzV385Ok3+yzlavNHZoedajjS4UyS21gabJYcobuigQPs/z71A9MdJFqQ==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
+      "integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.58.0",
-        "@typescript-eslint/types": "5.58.0",
-        "@typescript-eslint/typescript-estree": "5.58.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -8923,9 +8923,9 @@
           }
         },
         "semver": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-          "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8934,12 +8934,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
-      "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+      "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.58.0",
+        "@typescript-eslint/types": "5.59.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -11004,9 +11004,9 @@
           }
         },
         "semver": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-          "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "devDependencies": {
     "@types/node": "18.15.11",
-    "@typescript-eslint/eslint-plugin": "5.58.0",
-    "@typescript-eslint/parser": "5.58.0",
+    "@typescript-eslint/eslint-plugin": "5.59.0",
+    "@typescript-eslint/parser": "5.59.0",
     "assert-modules-support-case-insensitive-fs": "1.0.1",
     "assert-package-lock-is-consistent": "1.0.0",
     "eslint": "8.38.0",

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -89,7 +89,7 @@ export type ReportClientState = {
   readonly fullTestRuns: readonly FullTestRun[];
   lengthOfReadedJsonReportDataParts: number;
   readonly pathToScreenshotsDirectoryForReport: string | null;
-  readonly readJsonReportDataIntervalId?: number;
+  readonly readJsonReportDataObservers: MutationObserver[];
   testRunDetailsElementsByHash?: Record<RunHash, HTMLElement>;
 };
 

--- a/src/utils/report/client/domContentLoadedHandler.ts
+++ b/src/utils/report/client/domContentLoadedHandler.ts
@@ -1,6 +1,6 @@
 import {readJsonReportData as clientReadJsonReportData} from './readJsonReportData';
 
-import type {Mutable, ReportClientState} from '../../../types/internal';
+import type {ReportClientState} from '../../../types/internal';
 
 declare const reportClientState: ReportClientState;
 
@@ -12,9 +12,11 @@ const readJsonReportData = clientReadJsonReportData;
  * @internal
  */
 export function domContentLoadedHandler(): void {
-  readJsonReportData();
+  readJsonReportData(true);
 
-  window.clearInterval(reportClientState.readJsonReportDataIntervalId);
+  for (const observer of reportClientState.readJsonReportDataObservers) {
+    observer.disconnect();
+  }
 
-  (reportClientState as Mutable<ReportClientState>).readJsonReportDataIntervalId = 0;
+  reportClientState.readJsonReportDataObservers.length = 0;
 }

--- a/src/utils/report/client/index.ts
+++ b/src/utils/report/client/index.ts
@@ -29,3 +29,5 @@ export {
 } from './render';
 /** @internal */
 export {createSafeHtmlWithoutSanitize, sanitizeHtml, sanitizeJson} from './sanitizeHtml';
+/** @internal */
+export {setReadJsonReportDataObservers} from './setReadJsonReportDataObservers';

--- a/src/utils/report/client/initialScript.ts
+++ b/src/utils/report/client/initialScript.ts
@@ -4,11 +4,7 @@ import {clickOnRetry as clientClickOnRetry} from './clickOnRetry';
 import {clickOnStep as clientClickOnStep} from './clickOnStep';
 import {clickOnTestRun as clientClickOnTestRun} from './clickOnTestRun';
 import {domContentLoadedHandler as clientDomContentLoadedHandler} from './domContentLoadedHandler';
-import {readJsonReportData as clientReadJsonReportData} from './readJsonReportData';
-
-import type {Mutable, ReportClientState} from '../../../types/internal';
-
-declare const reportClientState: ReportClientState;
+import {setReadJsonReportDataObservers as clientSetReadJsonReportDataObservers} from './setReadJsonReportDataObservers';
 
 const addDomContentLoadedHandler = clientAddDomContentLoadedHandler;
 const addOnClickOnClass = clientAddOnClickOnClass;
@@ -16,7 +12,7 @@ const clickOnRetry = clientClickOnRetry;
 const clickOnStep = clientClickOnStep;
 const clickOnTestRun = clientClickOnTestRun;
 const domContentLoadedHandler = clientDomContentLoadedHandler;
-const readJsonReportData = clientReadJsonReportData;
+const setReadJsonReportDataObservers = clientSetReadJsonReportDataObservers;
 
 /**
  * Initial report page script.
@@ -28,12 +24,7 @@ export const initialScript = (): void => {
   addOnClickOnClass('step-expanded', clickOnStep);
   addOnClickOnClass('test-button', clickOnTestRun);
 
+  setReadJsonReportDataObservers();
+
   addDomContentLoadedHandler(domContentLoadedHandler);
-
-  if (!('readJsonReportDataIntervalId' in reportClientState)) {
-    readJsonReportData();
-
-    (reportClientState as Mutable<ReportClientState>).readJsonReportDataIntervalId =
-      window.setInterval(readJsonReportData, 50);
-  }
 };

--- a/src/utils/report/client/readJsonReportData.ts
+++ b/src/utils/report/client/readJsonReportData.ts
@@ -9,22 +9,35 @@ declare const reportClientState: ReportClientState;
  * This client function should not use scope variables (except global functions).
  * @internal
  */
-export function readJsonReportData(): void {
+export function readJsonReportData(areAllScriptsLoaded?: boolean): void {
   const {lengthOfReadedJsonReportDataParts} = reportClientState;
-  const scripts = document.querySelectorAll('script.e2edJsonReportData');
+  const scripts = document.querySelectorAll('body > script.e2edJsonReportData');
   const {length} = scripts;
 
   if (length <= lengthOfReadedJsonReportDataParts) {
     return;
   }
 
-  for (let i = lengthOfReadedJsonReportDataParts; i < length; i += 1) {
-    const fullTestRuns = JSON.parse(
-      scripts[i]?.textContent ?? `Cannot parse JSON report data from script number ${i}`,
-    ) as readonly FullTestRun[];
+  let hasParseErrorForLastScript = false;
 
-    (reportClientState.fullTestRuns as FullTestRun[]).push(...fullTestRuns);
+  for (let i = lengthOfReadedJsonReportDataParts; i < length; i += 1) {
+    try {
+      const fullTestRuns = JSON.parse(scripts[i]?.textContent ?? '') as readonly FullTestRun[];
+
+      (reportClientState.fullTestRuns as FullTestRun[]).push(...fullTestRuns);
+    } catch (error) {
+      if (i < length - 1 || areAllScriptsLoaded) {
+        // eslint-disable-next-line no-console
+        console.error(`Cannot parse JSON report data from script number ${i}`);
+      }
+
+      if (i === length - 1) {
+        hasParseErrorForLastScript = true;
+      }
+    }
   }
 
-  reportClientState.lengthOfReadedJsonReportDataParts = length;
+  const newLength = !areAllScriptsLoaded && hasParseErrorForLastScript ? length - 1 : length;
+
+  reportClientState.lengthOfReadedJsonReportDataParts = newLength;
 }

--- a/src/utils/report/client/setReadJsonReportDataObservers.ts
+++ b/src/utils/report/client/setReadJsonReportDataObservers.ts
@@ -1,0 +1,39 @@
+import {readJsonReportData as clientReadJsonReportData} from './readJsonReportData';
+
+import type {ReportClientState} from '../../../types/internal';
+
+declare const reportClientState: ReportClientState;
+
+const readJsonReportData = clientReadJsonReportData;
+
+/**
+ * Set mutation observers for reading JSON report data.
+ * This client function should not use scope variables (except global functions).
+ * @internal
+ */
+export function setReadJsonReportDataObservers(): void {
+  const observeChildList = {childList: true};
+  const {readJsonReportDataObservers} = reportClientState;
+  const scriptsObserver = new MutationObserver(() => readJsonReportData());
+
+  readJsonReportDataObservers.push(scriptsObserver);
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (document.body) {
+    scriptsObserver.observe(document.body, observeChildList);
+  } else {
+    const htmlObserver = new MutationObserver(() => {
+      const body = document.querySelector('body');
+
+      if (body) {
+        scriptsObserver.observe(body, observeChildList);
+
+        htmlObserver.disconnect();
+      }
+    });
+
+    readJsonReportDataObservers.push(htmlObserver);
+
+    htmlObserver.observe(document.documentElement, observeChildList);
+  }
+}

--- a/src/utils/report/getRetriesProps.ts
+++ b/src/utils/report/getRetriesProps.ts
@@ -15,8 +15,8 @@ export const getRetriesProps = ({retries}: ReportData): readonly RetryProps[] =>
     },
   );
 
-  if (retryProps[0]) {
-    (retryProps[0] as {hidden: boolean}).hidden = false;
+  if (retryProps.at(-1)) {
+    (retryProps.at(-1) as {hidden: boolean}).hidden = false;
   }
 
   return retryProps;

--- a/src/utils/report/render/renderReportToHtml.ts
+++ b/src/utils/report/render/renderReportToHtml.ts
@@ -25,6 +25,8 @@ export const renderReportToHtml = (reportData: ReportData): SafeHtml => {
   assertValueIsNotNull(reportFileName, 'reportFileName is not null');
 
   const retries = getRetriesProps(reportData);
+  const retryNumbers = retries.map(({retryIndex}) => retryIndex);
+  const maxRetry = Math.max(...retryNumbers);
 
   const safeHtml = sanitizeHtml`<!DOCTYPE html>
 <html lang="en">
@@ -32,7 +34,7 @@ export const renderReportToHtml = (reportData: ReportData): SafeHtml => {
   <body>
     ${renderNavigation(retries)}
     <div class="main" role="tabpanel">
-      <section class="main__section _position_left" aria-label="Retry 1">
+      <section class="main__section _position_left" aria-label="Retry ${maxRetry}">
         ${renderRetries(retries)}
         ${renderErrors(reportData.errors)}
       </section>

--- a/src/utils/report/render/renderRetriesButtons.ts
+++ b/src/utils/report/render/renderRetriesButtons.ts
@@ -11,7 +11,6 @@ import type {RetryProps, SafeHtml} from '../../../types/internal';
 export const renderRetriesButtons = (retries: readonly RetryProps[]): SafeHtml => {
   const retryNumbers = retries.map(({retryIndex}) => retryIndex);
   const maxRetry = Math.max(...retryNumbers);
-  const minRetry = Math.min(...retryNumbers);
   const buttons: SafeHtml[] = [];
 
   for (let index = 1; index <= maxRetry; index += 1) {
@@ -20,7 +19,7 @@ export const renderRetriesButtons = (retries: readonly RetryProps[]): SafeHtml =
     buttons[index] = renderRetryButton({
       disabled: !isRetry,
       retry: index,
-      selected: index === minRetry,
+      selected: index === maxRetry,
     });
   }
 

--- a/src/utils/report/render/renderScriptConstants.ts
+++ b/src/utils/report/render/renderScriptConstants.ts
@@ -15,6 +15,7 @@ export const renderScriptConstants = (): SafeHtml => {
     fullTestRuns: [],
     lengthOfReadedJsonReportDataParts: 0,
     pathToScreenshotsDirectoryForReport,
+    readJsonReportDataObservers: [],
   };
 
   return createSafeHtmlWithoutSanitize`

--- a/src/utils/report/render/renderScriptFunctions.ts
+++ b/src/utils/report/render/renderScriptFunctions.ts
@@ -16,6 +16,7 @@ import {
   renderTestRunDetails,
   renderTestRunError,
   sanitizeHtml,
+  setReadJsonReportDataObservers,
 } from '../client';
 
 import type {SafeHtml} from '../../../types/internal';
@@ -42,4 +43,5 @@ ${renderTestRunDescription.toString()}
 ${renderTestRunDetails.toString()}
 ${renderTestRunError.toString()}
 ${sanitizeHtml.toString()}
+${setReadJsonReportDataObservers.toString()}
 `;


### PR DESCRIPTION
fix: open last retry as default retry in HTML report

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Now in the HTML report console there may be errors when reading JSON with tests data.

## What is the new behavior?

In this pull request, the errors have been fixed (we take into account that the data from the last script tag may not be fully loaded at the time of parsing JSON from it).

## Other information

Also, in this pull request, we're making the last retry the default open retry, instead of first retry (in HTML report).
