### PR TITLE
fix: correct exit from docker after exit signals

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -130,6 +130,7 @@ rules:
     - {blankLine: always, prev: '*', next: return}
     - {blankLine: always, prev: throw, next: '*'}
     - {blankLine: always, prev: '*', next: throw}
+  prefer-destructuring: off
   simple-import-sort/exports: error
   simple-import-sort/imports:
     - error
@@ -206,7 +207,13 @@ rules:
   '@typescript-eslint/no-unused-expressions': error
   '@typescript-eslint/no-useless-empty-export': error
   '@typescript-eslint/parameter-properties': error
+  '@typescript-eslint/prefer-destructuring':
+    [error, {VariableDeclarator: {array: false, object: true}}]
+  '@typescript-eslint/prefer-enum-initializers': error
+  '@typescript-eslint/prefer-find': error
+  '@typescript-eslint/prefer-for-of': error
   '@typescript-eslint/quotes': [error, single, {avoidEscape: true}]
+  '@typescript-eslint/prefer-function-type': error
   '@typescript-eslint/sort-type-constituents': [error, {checkIntersections: false}]
 settings:
   import/extensions: [.ts]

--- a/autotests/bin/runDocker.sh
+++ b/autotests/bin/runDocker.sh
@@ -26,12 +26,15 @@ onExit() {
     then
         echo "Docker container from image $E2ED_DOCKER_IMAGE:$VERSION already stopped"
     else
+        sleep 18
+
         echo "Stop docker container from image $E2ED_DOCKER_IMAGE:$VERSION"
         docker stop --time=60 $CONTAINER_ID
     fi
 
     exit
 }
+
 
 echo "Run docker image $E2ED_DOCKER_IMAGE:$VERSION"
 

--- a/autotests/bin/runDocker.sh
+++ b/autotests/bin/runDocker.sh
@@ -35,7 +35,6 @@ onExit() {
     exit
 }
 
-
 echo "Run docker image $E2ED_DOCKER_IMAGE:$VERSION"
 
 trap "onExit" EXIT

--- a/bin/dockerEntrypoint.sh
+++ b/bin/dockerEntrypoint.sh
@@ -14,7 +14,9 @@ onExit() {
     if [[ $PID ]] && ps -p $PID > /dev/null
     then
         echo "$PID is running"
-        kill $PID
+        kill -USR1 $PID
+
+        sleep 16
     fi
 
     restoreE2edPackage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,12 @@
         "e2ed-init": "bin/init.js"
       },
       "devDependencies": {
-        "@types/node": "20.11.21",
-        "@typescript-eslint/eslint-plugin": "7.1.0",
-        "@typescript-eslint/parser": "7.1.0",
+        "@types/node": "20.11.25",
+        "@typescript-eslint/eslint-plugin": "7.1.1",
+        "@typescript-eslint/parser": "7.1.1",
         "assert-modules-support-case-insensitive-fs": "1.0.1",
         "assert-package-lock-is-consistent": "1.0.0",
-        "devtools-protocol": "0.0.1266247",
+        "devtools-protocol": "0.0.1269399",
         "eslint": "8.57.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-prettier": "9.1.0",
@@ -36,7 +36,7 @@
         "husky": "9.0.11",
         "prettier": "3.2.5",
         "testcafe": "3.5.0",
-        "typescript": "5.3.3"
+        "typescript": "5.4.2"
       },
       "engines": {
         "node": ">=16.11.1"
@@ -2202,9 +2202,9 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.11.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.21.tgz",
-      "integrity": "sha512-/ySDLGscFPNasfqStUuWWPfL78jompfIoVzLJPVVAHBh6rpG68+pI2Gk+fNLeI8/f1yPYL4s46EleVIc20F1Ow==",
+      "version": "20.11.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
+      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2216,16 +2216,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.1.0.tgz",
-      "integrity": "sha512-j6vT/kCulhG5wBmGtstKeiVr1rdXE4nk+DT1k6trYkwlrvW9eOF5ZbgKnd/YR6PcM4uTEXa0h6Fcvf6X7Dxl0w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.1.1.tgz",
+      "integrity": "sha512-zioDz623d0RHNhvx0eesUmGfIjzrk18nSBC8xewepKXbBvN/7c1qImV7Hg8TI1URTxKax7/zxfxj3Uph8Chcuw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.1.0",
-        "@typescript-eslint/type-utils": "7.1.0",
-        "@typescript-eslint/utils": "7.1.0",
-        "@typescript-eslint/visitor-keys": "7.1.0",
+        "@typescript-eslint/scope-manager": "7.1.1",
+        "@typescript-eslint/type-utils": "7.1.1",
+        "@typescript-eslint/utils": "7.1.1",
+        "@typescript-eslint/visitor-keys": "7.1.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2391,15 +2391,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.0.tgz",
-      "integrity": "sha512-V1EknKUubZ1gWFjiOZhDSNToOjs63/9O0puCgGS8aDOgpZY326fzFu15QAUjwaXzRZjf/qdsdBrckYdv9YxB8w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.1.tgz",
+      "integrity": "sha512-ZWUFyL0z04R1nAEgr9e79YtV5LbafdOtN7yapNbn1ansMyaegl2D4bL7vHoJ4HPSc4CaLwuCVas8CVuneKzplQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.1.0",
-        "@typescript-eslint/types": "7.1.0",
-        "@typescript-eslint/typescript-estree": "7.1.0",
-        "@typescript-eslint/visitor-keys": "7.1.0",
+        "@typescript-eslint/scope-manager": "7.1.1",
+        "@typescript-eslint/types": "7.1.1",
+        "@typescript-eslint/typescript-estree": "7.1.1",
+        "@typescript-eslint/visitor-keys": "7.1.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2419,13 +2419,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.0.tgz",
-      "integrity": "sha512-6TmN4OJiohHfoOdGZ3huuLhpiUgOGTpgXNUPJgeZOZR3DnIpdSgtt83RS35OYNNXxM4TScVlpVKC9jyQSETR1A==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.1.tgz",
+      "integrity": "sha512-cirZpA8bJMRb4WZ+rO6+mnOJrGFDd38WoXCEI57+CYBqta8Yc8aJym2i7vyqLL1vVYljgw0X27axkUXz32T8TA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.1.0",
-        "@typescript-eslint/visitor-keys": "7.1.0"
+        "@typescript-eslint/types": "7.1.1",
+        "@typescript-eslint/visitor-keys": "7.1.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2436,13 +2436,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.1.0.tgz",
-      "integrity": "sha512-UZIhv8G+5b5skkcuhgvxYWHjk7FW7/JP5lPASMEUoliAPwIH/rxoUSQPia2cuOj9AmDZmwUl1usKm85t5VUMew==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.1.1.tgz",
+      "integrity": "sha512-5r4RKze6XHEEhlZnJtR3GYeCh1IueUHdbrukV2KSlLXaTjuSfeVF8mZUVPLovidCuZfbVjfhi4c0DNSa/Rdg5g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.1.0",
-        "@typescript-eslint/utils": "7.1.0",
+        "@typescript-eslint/typescript-estree": "7.1.1",
+        "@typescript-eslint/utils": "7.1.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2463,9 +2463,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.0.tgz",
-      "integrity": "sha512-qTWjWieJ1tRJkxgZYXx6WUYtWlBc48YRxgY2JN1aGeVpkhmnopq+SUC8UEVGNXIvWH7XyuTjwALfG6bFEgCkQA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.1.tgz",
+      "integrity": "sha512-KhewzrlRMrgeKm1U9bh2z5aoL4s7K3tK5DwHDn8MHv0yQfWFz/0ZR6trrIHHa5CsF83j/GgHqzdbzCXJ3crx0Q==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2476,13 +2476,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.0.tgz",
-      "integrity": "sha512-k7MyrbD6E463CBbSpcOnwa8oXRdHzH1WiVzOipK3L5KSML92ZKgUBrTlehdi7PEIMT8k0bQixHUGXggPAlKnOQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.1.tgz",
+      "integrity": "sha512-9ZOncVSfr+sMXVxxca2OJOPagRwT0u/UHikM2Rd6L/aB+kL/QAuTnsv6MeXtjzCJYb8PzrXarypSGIPx3Jemxw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.1.0",
-        "@typescript-eslint/visitor-keys": "7.1.0",
+        "@typescript-eslint/types": "7.1.1",
+        "@typescript-eslint/visitor-keys": "7.1.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2549,17 +2549,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.0.tgz",
-      "integrity": "sha512-WUFba6PZC5OCGEmbweGpnNJytJiLG7ZvDBJJoUcX4qZYf1mGZ97mO2Mps6O2efxJcJdRNpqweCistDbZMwIVHw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.1.tgz",
+      "integrity": "sha512-thOXM89xA03xAE0lW7alstvnyoBUbBX38YtY+zAUcpRPcq9EIhXPuJ0YTv948MbzmKh6e1AUszn5cBFK49Umqg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.1.0",
-        "@typescript-eslint/types": "7.1.0",
-        "@typescript-eslint/typescript-estree": "7.1.0",
+        "@typescript-eslint/scope-manager": "7.1.1",
+        "@typescript-eslint/types": "7.1.1",
+        "@typescript-eslint/typescript-estree": "7.1.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2574,12 +2574,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.0.tgz",
-      "integrity": "sha512-FhUqNWluiGNzlvnDZiXad4mZRhtghdoKW6e98GoEOYSu5cND+E39rG5KwJMUzeENwm1ztYBRqof8wMLP+wNPIA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.1.tgz",
+      "integrity": "sha512-yTdHDQxY7cSoCcAtiBzVzxleJhkGB9NncSIyMYe2+OGON1ZsP9zOPws/Pqgopa65jvknOjlk/w7ulPlZ78PiLQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.1.0",
+        "@typescript-eslint/types": "7.1.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -3409,9 +3409,9 @@
       "integrity": "sha512-fYXbFSeilT7bnKWFi4OERSPHdtaEoDGn4aUhV5Nly6/I+Tp6JZ/6Icmd7LVIF5euyodGpxz2e/bfUmDnIdSIDw=="
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1266247",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1266247.tgz",
-      "integrity": "sha512-kxT+QYvtoz5DA85ZqUe3stL0dmjlMWGvxEtSdd9dhduDY7VyY8cjzfs8sHXnHoBgBLklUFZc5V6ffHWdK7l4gw==",
+      "version": "0.0.1269399",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1269399.tgz",
+      "integrity": "sha512-CVFbZYBunJ+vk3ft+ZsxPqPs1RigTgrMGjCrS/r9Lm9SvKoxrr1FztZ09znTN45d8OgMX4Cz5oETBgHPUxwpLw==",
       "dev": true
     },
     "node_modules/diff": {
@@ -7516,9 +7516,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "testcafe-without-typecheck": "3.5.0-rc.2"
   },
   "devDependencies": {
-    "@types/node": "20.11.21",
-    "@typescript-eslint/eslint-plugin": "7.1.0",
-    "@typescript-eslint/parser": "7.1.0",
+    "@types/node": "20.11.25",
+    "@typescript-eslint/eslint-plugin": "7.1.1",
+    "@typescript-eslint/parser": "7.1.1",
     "assert-modules-support-case-insensitive-fs": "1.0.1",
     "assert-package-lock-is-consistent": "1.0.0",
-    "devtools-protocol": "0.0.1266247",
+    "devtools-protocol": "0.0.1269399",
     "eslint": "8.57.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-prettier": "9.1.0",
@@ -47,7 +47,7 @@
     "husky": "9.0.11",
     "prettier": "3.2.5",
     "testcafe": "3.5.0",
-    "typescript": "5.3.3"
+    "typescript": "5.4.2"
   },
   "peerDependencies": {
     "@types/node": ">=16.11.1",

--- a/src/constants/log.ts
+++ b/src/constants/log.ts
@@ -13,15 +13,15 @@ export const enum LogEventStatus {
  * Type of `LogEvent`.
  */
 export const enum LogEventType {
-  Action,
-  Assert,
-  Entity,
-  Util,
-  InternalAction,
-  InternalAssert,
-  InternalCore,
-  InternalUtil,
-  Unspecified,
+  Action = 1,
+  Assert = 2,
+  Entity = 3,
+  Util = 4,
+  InternalAction = 5,
+  InternalAssert = 6,
+  InternalCore = 7,
+  InternalUtil = 8,
+  Unspecified = 9,
 }
 
 /**

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -21,7 +21,7 @@ declare module 'bin-v8-flags-filter' {
   }>;
 
   /**
-   * Filters out nodejs cli options and runs node module on cliPath.
+   * Filters out `nodejs` cli options and runs node module on `cliPath`.
    */
   const v8FlagsFilter: (cliPath: string, options: Options) => void;
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -6,6 +6,7 @@
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface NodeRequire {
+  // eslint-disable-next-line @typescript-eslint/prefer-function-type
   <ModuleExports = import('./utils').Any>(modulePath: string): ModuleExports;
 }
 

--- a/src/types/selectors.ts
+++ b/src/types/selectors.ts
@@ -38,12 +38,8 @@ type ReplaceObjectSelectors<Obj extends object> = Readonly<{
             (...args: A2): ReplaceSelector<R2>;
             (...args: A1): ReplaceSelector<R1>;
           }
-        : Obj[Key] extends {
-              (...args: infer A1): infer R1;
-            }
-          ? {
-              (...args: A1): ReplaceSelector<R1>;
-            }
+        : Obj[Key] extends (...args: infer A1) => infer R1
+          ? (...args: A1) => ReplaceSelector<R1>
           : Obj[Key];
 }>;
 

--- a/src/utils/end/setProcessEndHandlers.ts
+++ b/src/utils/end/setProcessEndHandlers.ts
@@ -5,7 +5,7 @@ import {generalLog} from '../generalLog';
 import {endE2ed} from './endE2ed';
 
 /**
- * nodejs e2ed process end hanlder.
+ * `nodejs` e2ed process end hanlder.
  * @internal
  */
 const endHandler = (signal: NodeJS.Signals): void => {
@@ -15,10 +15,12 @@ const endHandler = (signal: NodeJS.Signals): void => {
 };
 
 /**
- * Set nodejs e2ed process end hanlders (SIGINT, SIGTERM).
+ * Set `nodejs` e2ed process end hanlders (`SIGHUP`, `SIGINT`, `SIGTERM`, `SIGUSR1`).
  * @internal
  */
 export const setProcessEndHandlers = (): void => {
+  process.on('SIGHUP', endHandler);
   process.on('SIGINT', endHandler);
   process.on('SIGTERM', endHandler);
+  process.on('SIGUSR1', endHandler);
 };

--- a/src/utils/error/E2edError.ts
+++ b/src/utils/error/E2edError.ts
@@ -85,7 +85,7 @@ export class E2edError extends Error {
   }
 
   /**
-   * Custom presentation of error for nodejs `inspect`.
+   * Custom presentation of error for `nodejs` `inspect`.
    */
   [inspect.custom](): string {
     return this.toString();

--- a/src/utils/events/registerEndE2edRunEvent.ts
+++ b/src/utils/events/registerEndE2edRunEvent.ts
@@ -10,11 +10,19 @@ import {runAfterPackFunctions} from './runAfterPackFunctions';
 
 import type {ReportData} from '../../types/internal';
 
+let isEndAlreadyCalled = false;
+
 /**
  * Registers end e2ed run event (for report) after closing of all tests.
  * @internal
  */
 export const registerEndE2edRunEvent = async (): Promise<void> => {
+  if (isEndAlreadyCalled) {
+    return;
+  }
+
+  isEndAlreadyCalled = true;
+
   generalLog('Starting to close e2ed...');
 
   let reportData: ReportData | undefined;

--- a/src/utils/report/writeHtmlReport.ts
+++ b/src/utils/report/writeHtmlReport.ts
@@ -12,7 +12,7 @@ import {renderReportToHtml} from './render';
 import type {FilePathFromRoot, ReportData, UtcTimeInMs} from '../../types/internal';
 
 /**
- * Writes HTML report (report.html file) with test runs results.
+ * Writes HTML report (`report.html` file) with test runs results.
  * @internal
  */
 export const writeHtmlReport = async (reportData: ReportData): Promise<void> => {

--- a/src/utils/retry/runRetry.ts
+++ b/src/utils/retry/runRetry.ts
@@ -40,7 +40,8 @@ export const runRetry = (runRetryOptions: RunRetryOptions): Promise<void> =>
     setTestsSubprocess(newTestsSubprocess);
 
     newTestsSubprocess.on('error', reject);
-    newTestsSubprocess.on('exit', (exitCode) => {
+
+    newTestsSubprocess.on('exit', (exitCode): void => {
       const error = new E2edError(
         `Tests subprocess with label "${runLabel}" exit with non-zero exit code ${String(
           exitCode,

--- a/src/utils/valueToString/wrapStringForLogs.ts
+++ b/src/utils/valueToString/wrapStringForLogs.ts
@@ -17,7 +17,7 @@ function toMultipleString(this: StringForLogs): string {
 
 /**
  * If the text consists of several lines, replaces the text with an object
- * with a more beautiful presentation through nodejs `inspect`.
+ * with a more beautiful presentation through `nodejs` `inspect`.
  * @internal
  */
 export const wrapStringForLogs = (text: string, options?: Options): StringForLogs | string => {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

fix: writes HTML report after exit signals to `dockerEntrypoint.sh`.
chore: turn on more `@typescript-eslint` rules.
chore: update devDependencies (`typescript`, `@typescript-eslint/*`, etc).