### PR TITLE
fix: error with comparing `E2ED_DEBUG` with empty string

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -225,6 +225,7 @@ rules:
   '@typescript-eslint/strict-boolean-expressions': [error, {allowNullableBoolean: true}]
   '@typescript-eslint/switch-exhaustiveness-check':
     [error, {allowDefaultCaseForExhaustiveSwitch: false, requireDefaultForNonUnion: true}]
+  '@typescript-eslint/typedef': error
 settings:
   import/extensions: [.ts]
   import/resolver: {node: {extensions: [.ts]}}

--- a/src/PageRoute.ts
+++ b/src/PageRoute.ts
@@ -10,7 +10,8 @@ export abstract class PageRoute<Params = undefined> extends Route<Params> {
   getOrigin(): Url {
     const {E2ED_ORIGIN} = process.env;
 
-    if (E2ED_ORIGIN !== undefined) {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (E2ED_ORIGIN) {
       return E2ED_ORIGIN.replace(SLASHES_AT_THE_END_REGEXP, '') as Url;
     }
 

--- a/src/bin/localEntrypoint.ts
+++ b/src/bin/localEntrypoint.ts
@@ -4,7 +4,8 @@ import v8FlagsFilter from 'bin-v8-flags-filter';
 
 import {e2edEnvironment, INSTALLED_E2ED_DIRECTORY_PATH} from '../constants/internal';
 
-if (e2edEnvironment.E2ED_DEBUG !== undefined) {
+// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+if (e2edEnvironment.E2ED_DEBUG) {
   process.argv.push('--inspect-brk');
 }
 

--- a/src/utils/retry/getTestsSubprocessForkOptions.ts
+++ b/src/utils/retry/getTestsSubprocessForkOptions.ts
@@ -9,7 +9,8 @@ import type {ForkOptions} from 'node:child_process';
  * @internal
  */
 export const getTestsSubprocessForkOptions = (): ForkOptions | undefined => {
-  if (e2edEnvironment.E2ED_DEBUG === undefined) {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  if (!e2edEnvironment.E2ED_DEBUG) {
     return undefined;
   }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

fix: error with comparing `E2ED_DEBUG` with empty string.
chore: turn on more `@typescript-eslint/*` rules.