### PR TITLE
fix: show failed assert in HTML reports for all asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="e2ed logo" src="https://raw.github.com/joomcode/e2ed/main/logo.svg?sanitize=true">
+![e2ed logo](https://raw.githubusercontent.com/joomcode/e2ed/main/logo.svg)
 
 # e2ed
 

--- a/autotests/configurator/mapLogPayloadInConsole.ts
+++ b/autotests/configurator/mapLogPayloadInConsole.ts
@@ -20,6 +20,7 @@ export const mapLogPayloadInConsole: MapLogPayloadInConsole = (message, payload)
   if (
     message.startsWith('Caught an error when running tests in retry') ||
     message.startsWith('Usage:') ||
+    message.includes('Logs were written') ||
     message.includes('report was written')
   ) {
     return payload;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@playwright/browser-chromium": "1.50.1",
-        "@types/node": "22.13.5",
+        "@types/node": "22.13.9",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
         "assert-modules-support-case-insensitive-fs": "1.0.1",
@@ -33,8 +33,8 @@
         "eslint-plugin-simple-import-sort": "12.1.1",
         "eslint-plugin-typescript-sort-keys": "3.3.0",
         "husky": "9.1.7",
-        "prettier": "3.5.2",
-        "typescript": "5.7.3"
+        "prettier": "3.5.3",
+        "typescript": "5.8.2"
       },
       "engines": {
         "node": ">=20.16.0"
@@ -228,9 +228,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
-      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "version": "22.13.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
+      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2784,9 +2784,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
-      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3308,9 +3308,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@playwright/browser-chromium": "1.50.1",
-    "@types/node": "22.13.5",
+    "@types/node": "22.13.9",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "assert-modules-support-case-insensitive-fs": "1.0.1",
@@ -44,8 +44,8 @@
     "eslint-plugin-simple-import-sort": "12.1.1",
     "eslint-plugin-typescript-sort-keys": "3.3.0",
     "husky": "9.1.7",
-    "prettier": "3.5.2",
-    "typescript": "5.7.3"
+    "prettier": "3.5.3",
+    "typescript": "5.8.2"
   },
   "peerDependencies": {
     "@types/node": ">=20",

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -25,6 +25,7 @@ export type ReportData = Readonly<{
   failedTestsMainParams: readonly string[];
   fullTestRuns: readonly FullTestRun[];
   liteReportFileName: string | null;
+  logFileName: string | null;
   notIncludedInPackTests: readonly TestFilePath[];
   reportFileName: string | null;
   retries: readonly Retry[];

--- a/src/utils/events/showLogAboutLogFile.ts
+++ b/src/utils/events/showLogAboutLogFile.ts
@@ -1,0 +1,28 @@
+import {join} from 'node:path';
+
+import {
+  ABSOLUTE_PATH_TO_PROJECT_ROOT_DIRECTORY,
+  REPORTS_DIRECTORY_PATH,
+} from '../../constants/internal';
+
+import {getFileSize} from '../fs';
+import {generalLog} from '../generalLog';
+import {getFileSizeInMb} from '../getFileSizeInMb';
+
+/**
+ * Shows log about log file (`pack-logs.log`).
+ * @internal
+ */
+export const showLogAboutLogFile = async (logFileName: string): Promise<void> => {
+  const logFilePath = join(
+    ABSOLUTE_PATH_TO_PROJECT_ROOT_DIRECTORY,
+    REPORTS_DIRECTORY_PATH,
+    logFileName,
+  );
+
+  const logFileSizeInBytes = await getFileSize(logFilePath);
+
+  const logFileSizeInMb = getFileSizeInMb(logFileSizeInBytes);
+
+  generalLog(`Logs were written (${logFileSizeInMb}) to "file://${logFilePath}"`);
+};

--- a/src/utils/events/writeReports.ts
+++ b/src/utils/events/writeReports.ts
@@ -1,5 +1,7 @@
 import {writeHtmlReport, writeLiteJsonReport} from '../report';
 
+import {showLogAboutLogFile} from './showLogAboutLogFile';
+
 import type {LiteReport, ReportData} from '../../types/internal';
 
 type Options = Readonly<{liteReport: LiteReport; reportData: ReportData}>;
@@ -9,7 +11,11 @@ type Options = Readonly<{liteReport: LiteReport; reportData: ReportData}>;
  * @internal
  */
 export const writeReports = async ({liteReport, reportData}: Options): Promise<void> => {
-  const {liteReportFileName, reportFileName} = reportData;
+  const {liteReportFileName, logFileName, reportFileName} = reportData;
+
+  if (logFileName !== null) {
+    await showLogAboutLogFile(logFileName);
+  }
 
   if (liteReportFileName !== null) {
     await writeLiteJsonReport(liteReport);

--- a/src/utils/expect/additionalMatchers.ts
+++ b/src/utils/expect/additionalMatchers.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+
 import {toMatchScreenshot} from './toMatchScreenshot';
 
 import type {Expect} from './Expect';
@@ -23,63 +25,61 @@ export const additionalMatchers: NonSelectorAdditionalMatchers<unknown> & Select
       ),
     );
   },
-  eql(this: Expect, expected) {
+  async eql(this: Expect, expected) {
     const {actualValue, description} = this;
 
-    return Promise.resolve(expect(actualValue, description).toEqual(expected));
+    return expect(actualValue, description).toEqual(expected);
   },
-  gt(this: Expect, expected) {
+  async gt(this: Expect, expected) {
     const {actualValue, description} = this;
 
-    return Promise.resolve(expect(actualValue, description).toBeGreaterThan(expected));
+    return expect(actualValue, description).toBeGreaterThan(expected);
   },
-  gte(this: Expect, expected) {
+  async gte(this: Expect, expected) {
     const {actualValue, description} = this;
 
-    return Promise.resolve(expect(actualValue, description).toBeGreaterThanOrEqual(expected));
+    return expect(actualValue, description).toBeGreaterThanOrEqual(expected);
   },
-  lt(this: Expect, expected) {
+  async lt(this: Expect, expected) {
     const {actualValue, description} = this;
 
-    return Promise.resolve(expect(actualValue, description).toBeLessThan(expected));
+    return expect(actualValue, description).toBeLessThan(expected);
   },
-  lte(this: Expect, expected) {
+  async lte(this: Expect, expected) {
     const {actualValue, description} = this;
 
-    return Promise.resolve(expect(actualValue, description).toBeLessThanOrEqual(expected));
+    return expect(actualValue, description).toBeLessThanOrEqual(expected);
   },
-  match(this: Expect, expected) {
+  async match(this: Expect, expected) {
     const {actualValue, description} = this;
 
-    return Promise.resolve(expect(actualValue, description).toMatch(expected));
+    return expect(actualValue, description).toMatch(expected);
   },
-  notContains(this: Expect, expected) {
+  async notContains(this: Expect, expected) {
     const {actualValue, description} = this;
 
     if (typeof actualValue === 'string' || Array.isArray(actualValue)) {
-      return Promise.resolve(expect(actualValue, description).not.toContain(expected));
+      return expect(actualValue, description).not.toContain(expected);
     }
 
-    return Promise.resolve(
-      expect(actualValue, description).not.toEqual(
-        expect.objectContaining(expected as Record<string, unknown>),
-      ),
+    return expect(actualValue, description).not.toEqual(
+      expect.objectContaining(expected as Record<string, unknown>),
     );
   },
-  notEql(this: Expect, expected) {
+  async notEql(this: Expect, expected) {
     const {actualValue, description} = this;
 
-    return Promise.resolve(expect(actualValue, description).not.toEqual(expected));
+    return expect(actualValue, description).not.toEqual(expected);
   },
-  notOk(this: Expect) {
+  async notOk(this: Expect) {
     const {actualValue, description} = this;
 
-    return Promise.resolve(expect(actualValue, description).not.toBeTruthy());
+    return expect(actualValue, description).not.toBeTruthy();
   },
-  ok(this: Expect) {
+  async ok(this: Expect) {
     const {actualValue, description} = this;
 
-    return Promise.resolve(expect(actualValue, description).toBeTruthy());
+    return expect(actualValue, description).toBeTruthy();
   },
 
   toMatchScreenshot(this: Expect, expectedScreenshotId, options = {}) {

--- a/src/utils/expect/createExpectMethod.ts
+++ b/src/utils/expect/createExpectMethod.ts
@@ -8,7 +8,7 @@ import {addTimeoutToPromise} from '../promise';
 import {Selector} from '../selectors';
 import {setReadonlyProperty} from '../setReadonlyProperty';
 import {isThenable} from '../typeGuards';
-import {valueToString, wrapStringForLogs} from '../valueToString';
+import {removeStyleFromString, valueToString, wrapStringForLogs} from '../valueToString';
 
 import {additionalMatchers} from './additionalMatchers';
 import {applyAdditionalMatcher} from './applyAdditionalMatcher';
@@ -99,7 +99,7 @@ export const createExpectMethod = (
       const logPayload = {
         assertionArguments: args,
         ...additionalLogFields,
-        error,
+        error: error?.message === undefined ? undefined : removeStyleFromString(error.message),
         logEventStatus: error ? LogEventStatus.Failed : LogEventStatus.Passed,
         selector:
           selectorPropertyRetryData?.selector.description ??

--- a/src/utils/fs/writeFile.ts
+++ b/src/utils/fs/writeFile.ts
@@ -18,7 +18,7 @@ export const writeFile = async (
   if (data instanceof Buffer) {
     buffer = data;
   } else {
-    buffer = Buffer.from(data);
+    buffer = Buffer.from(data as string);
   }
 
   const directoryPath = dirname(path) as DirectoryPathFromRoot;

--- a/src/utils/fs/writeFile.ts
+++ b/src/utils/fs/writeFile.ts
@@ -13,11 +13,19 @@ export const writeFile = async (
   path: FilePathFromRoot,
   data: Uint8Array | string,
 ): Promise<void> => {
+  let buffer: Buffer;
+
+  if (data instanceof Buffer) {
+    buffer = data;
+  } else {
+    buffer = Buffer.from(data);
+  }
+
   const directoryPath = dirname(path) as DirectoryPathFromRoot;
 
   await createDirectory(directoryPath);
 
-  const sourceStream = Readable.from(data);
+  const sourceStream = Readable.from(buffer);
   const targetStream = createWriteStream(path);
 
   sourceStream.pipe(targetStream);

--- a/src/utils/getFileSizeInMb.ts
+++ b/src/utils/getFileSizeInMb.ts
@@ -1,0 +1,10 @@
+const bytesInMb = 1_048_576;
+
+/**
+ * Get file size in MB by size in bytes.
+ */
+export const getFileSizeInMb = (fileSizeInBytes: number): string => {
+  const fileSizeInMb = (fileSizeInBytes / bytesInMb).toFixed(2);
+
+  return `${fileSizeInMb} MB`;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,6 +35,7 @@ export {E2edError, getStackTrace} from './error';
 export {getFunctionPresentationForLogs, setCustomInspectOnFunction} from './fn';
 export {writeFile} from './fs';
 export {getDurationWithUnits} from './getDurationWithUnits';
+export {getFileSizeInMb} from './getFileSizeInMb';
 export {getHash} from './getHash';
 export {getKeysCounter} from './getKeysCounter';
 export {getContentJsonHeaders} from './http';

--- a/src/utils/report/client/render/renderTestRunError.ts
+++ b/src/utils/report/client/render/renderTestRunError.ts
@@ -15,7 +15,7 @@ export function renderTestRunError(runError: RunError): SafeHtml {
   }
 
   // eslint-disable-next-line no-control-regex
-  const stylesRegexp = /(\\x1B\[)|(\x1B\[)|(\\u001b\[)[\d;]+m/gi;
+  const stylesRegexp = /((\\x1B\[)|(\x1B\[)|(\\u001b\[)|(\u001b\[))[\d;]*m/gi;
 
   const runErrorWithoutStyle = String(runError).replace(stylesRegexp, '');
 

--- a/src/utils/report/collectReportData.ts
+++ b/src/utils/report/collectReportData.ts
@@ -22,7 +22,7 @@ export const collectReportData = async ({
   notIncludedInPackTests,
   startInfo,
 }: FullEventsData): Promise<ReportData> => {
-  const {liteReportFileName, reportFileName} = getFullPackConfig();
+  const {liteReportFileName, logFileName, reportFileName} = getFullPackConfig();
 
   const errors = await getReportErrors(fullTestRuns, notIncludedInPackTests);
 
@@ -47,6 +47,7 @@ export const collectReportData = async ({
     failedTestsMainParams,
     fullTestRuns,
     liteReportFileName,
+    logFileName,
     notIncludedInPackTests,
     reportFileName,
     retries,

--- a/src/utils/report/writeHtmlReport.ts
+++ b/src/utils/report/writeHtmlReport.ts
@@ -9,12 +9,11 @@ import {assertValueIsNotNull} from '../asserts';
 import {getFileSize, writeFile} from '../fs';
 import {generalLog} from '../generalLog';
 import {getDurationWithUnits} from '../getDurationWithUnits';
+import {getFileSizeInMb} from '../getFileSizeInMb';
 
 import {renderReportToHtml} from './render';
 
 import type {FilePathFromRoot, ReportData, UtcTimeInMs} from '../../types/internal';
-
-const bytesInMb = 1_048_576;
 
 /**
  * Writes HTML report (`report.html` file) with test runs results.
@@ -38,11 +37,11 @@ export const writeHtmlReport = async (reportData: ReportData): Promise<void> => 
 
   const reportFileSizeInBytes = await getFileSize(reportFilePath);
 
-  const reportFileSizeInMb = (reportFileSizeInBytes / bytesInMb).toFixed(2);
+  const reportFileSizeInMb = getFileSizeInMb(reportFileSizeInBytes);
 
   const durationWithUnits = getDurationWithUnits(Date.now() - startTimeInMs);
 
   generalLog(
-    `HTML report was written (${reportFileSizeInMb} MB) to "${reportFilePath}" in ${durationWithUnits}`,
+    `HTML report was written (${reportFileSizeInMb}) to "file://${reportFilePath}" in ${durationWithUnits}`,
   );
 };

--- a/src/utils/report/writeLiteJsonReport.ts
+++ b/src/utils/report/writeLiteJsonReport.ts
@@ -39,6 +39,6 @@ export const writeLiteJsonReport = async (liteReport: LiteReport): Promise<void>
   const durationWithUnits = getDurationWithUnits(Date.now() - startTimeInMs);
 
   generalLog(
-    `Lite JSON report was written (${reportFileSizeInKb} KB) to "${reportFilePath}" in ${durationWithUnits}`,
+    `Lite JSON report was written (${reportFileSizeInKb} KB) to "file://${reportFilePath}" in ${durationWithUnits}`,
   );
 };

--- a/src/utils/valueToString/removeStyleFromString.ts
+++ b/src/utils/valueToString/removeStyleFromString.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-control-regex
-const stylesRegexp = /(\\x1B\[)|(\x1B\[)|(\\u001b\[)[\d;]+m/gi;
+const stylesRegexp = /((\\x1B\[)|(\x1B\[)|(\\u001b\[)|(\u001b\[))[\d;]*m/gi;
 
 /**
  * Removes console (terminal) styles from a string (like `\x1B[3m...`).

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "exactOptionalPropertyTypes": true,
     "incremental": true,
     "isolatedDeclarations": true,
+    "libReplacement": false,
     "module": "CommonJS",
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

fix: show failed assert in HTML reports for all asserts.
fix: show link to logs file in the end of tests run.
fix: remove style symbols from Playwright error messages.
chore: update `devDependencies` (`prettier`, `typescript`, etc.).